### PR TITLE
chore: bootstrap Spring Boot 3.5.5 + health endpoint + Swagger (sprin…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,17 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>3.18.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.8.13</version>
+		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/com/example/todos/controller/HealthController.java
+++ b/src/main/java/com/example/todos/controller/HealthController.java
@@ -1,0 +1,17 @@
+package com.example.todos.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1")
+public class HealthController {
+
+    @GetMapping("/health")
+    public ResponseEntity<?> health() {
+        return ResponseEntity.ok(
+                java.util.Map.of("status","OK","service","todo-api","version","0.0.1")
+        );
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,20 @@
 spring.application.name=todo-api-spring
+
+# --- H2 (dev) ---
+spring.datasource.url=jdbc:h2:mem:todos;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=update
+spring.h2.console.enabled=true
+
+# JPA
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+
+# OpenAPI / Swagger (springdoc 2.x - Boot 3.5.5)
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+
+# App
+server.port=8080
+


### PR DESCRIPTION
Bootstrap Spring Boot 3.5.5 project (Web, Validation, JPA, H2, PostgreSQL).
Adds /api/v1/health and Swagger/OpenAPI (springdoc 2.8.13).

Closes #1
Closes #2
Closes #3

Milestone: M1 – Bootstrap & Infra
