### PR TITLE
Feat/m5 db docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+target/
+.idea/
+*.iml
+.git/
+.gitignore
+.mvn/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# ---------- Build stage ----------
+FROM maven:3.9.8-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+
+RUN mvn -q -DskipTests dependency:go-offline
+
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+# ---------- Runtime stage ----------
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+
+RUN useradd -u 10001 spring && chown -R spring:spring /app
+COPY --from=build /app/target/*-SNAPSHOT.jar /app/app.jar
+EXPOSE 8080
+USER spring
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app/app.jar"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,19 @@ curl -i -X POST "http://localhost:8080/api/v1/users" \
   - Query params: `status`, `dueBefore`, `page`, `size`, `sort` (e.g., `dueDate,desc`)
   - Response headers: `X-Total-Count`, `X-Total-Pages`, `X-Page`, `X-Size`
 
+## M5 – Docker & PostgreSQL
+
+### Profiles
+- **dev** (H2 in-memory): local development.
+- **prod** (PostgreSQL): used in Docker Compose.
+
+### Run with Docker Compose (PostgreSQL)
+```bash
+docker compose build
+docker compose up -d
+# Health check (should return JSON OK)
+curl -s http://localhost:8080/api/v1/health
+
 
 
 In this project we learned to:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_DB: todos
+      POSTGRES_USER: todo
+      POSTGRES_PASSWORD: todo
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U todo -d todos"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  app:
+    build: .
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: prod
+      SPRING_DATASOURCE_URL: jdbc:postgresql://db:5432/todos
+      SPRING_DATASOURCE_USERNAME: todo
+      SPRING_DATASOURCE_PASSWORD: todo
+    ports:
+      - "8080:8080"
+
+volumes:
+  pgdata:

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,14 @@
+# --- DEV (H2 en memoria) ---
+server.port=8080
+
+spring.datasource.url=jdbc:h2:mem:todos
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,13 @@
+# --- PROD (PostgreSQL) ---
+server.port=8080
+
+spring.datasource.url=jdbc:postgresql://localhost:5432/todos
+spring.datasource.username=todo
+spring.datasource.password=todo
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.jdbc.time_zone=UTC
+
+spring.h2.console.enabled=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,20 +1,3 @@
 spring.application.name=todo-api-spring
-spring.jpa.open-in-view=false
-# --- H2 (dev) ---
-spring.datasource.url=jdbc:h2:mem:todos;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
-spring.datasource.username=sa
-spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=update
-spring.h2.console.enabled=true
 
-# JPA
-spring.jpa.show-sql=true
-spring.jpa.properties.hibernate.format_sql=true
-
-# OpenAPI / Swagger (springdoc 2.x - Boot 3.5.5)
-springdoc.api-docs.path=/api-docs
-springdoc.swagger-ui.path=/swagger-ui.html
-
-# App
-server.port=8080
 


### PR DESCRIPTION
- Add application-prod.properties (PostgreSQL).
- Add Dockerfile and docker-compose (db + app) with healthcheck.
- Dev profile keeps H2; prod uses Postgres via compose.
- README: Docker quickstart and profiles.

Closes #27 
Closes #28 
Closes#29